### PR TITLE
Adds Axios v1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ treats each tag as a servlet. It may not save your api, but it will save your ey
 `npx taggem [-s] [--service] [path/to/input.y(a)ml] [path/to/output/]`
 This runs the generator in "microservice mode" where your generated api code will be placed into a single directory of the same name as the api `title`. This ignores `tags` for further organization.
 
+## Axios Version
+
+The code generator currently supports Axios version < 1 by default. In Axios version 1.0 header types were introduced as a breaking change. Passing in the Axios version your project uses as the `v` argument generates correct header types in the service files. See https://github.com/axios/axios/blob/v1.x/CHANGELOG.md#100---2022-10-04 for more information on 1.0 changes.
+
 ## Results
 
 -   One or more directories (depending on how the generator was invoked) containing the a file with typescript functions that will return a configuration object detailing how to access an api resource. E.g. (assuming -\-m),

--- a/cli.js
+++ b/cli.js
@@ -15,7 +15,6 @@ const yargs = require("yargs")
 	.alias("m", "monolith")
 	.alias("s", "service")
 	.alias("n", "name")
-	.alias("v", "major Axios version");
 
 const argv = yargs.argv;
 

--- a/cli.js
+++ b/cli.js
@@ -1,17 +1,21 @@
 #!/usr/bin/env node
+
 const yargs = require("yargs")
-	.usage(`Usage: npx taggem [-m] [-s] [-n] path/to/input-file.y(a)ml /path/to/output/directory/`)
+	.usage(`Usage: npx taggem [-m] [-s] [-n] [-v] path/to/input-file.y(a)ml /path/to/output/directory/`)
 	.describe({
 		m: "Treat as a monolithic API and split directories by open api tag.",
 		s: "Treat as a microservice API, assume there are other files to process, and make a single directory to store api functions ignoring tags.",
-		n: "The desired name of this api service."
+		n: "The desired name of this api service.",
+		v: "The major Axios version to support - defaults to 0. See header type changes in 1.0 release https://github.com/axios/axios/blob/v1.x/CHANGELOG.md#100---2022-10-04"
 	})
 	.string(["n"])
 	.boolean(["m", "s"])
+	.number("v")
 	.help()
 	.alias("m", "monolith")
 	.alias("s", "service")
-	.alias("n", "name");
+	.alias("n", "name")
+	.alias("v", "major Axios version");
 
 const argv = yargs.argv;
 
@@ -22,6 +26,7 @@ if (argv._.length < 2) {
 	const userOutputDirectory = argv._[1];
 	const isApiMonolith = argv.m || !argv.s;
 	const serviceName = argv.n;
+	const axiosVersion = argv.v;
 
-	require("./index").generate(inputFile, userOutputDirectory, isApiMonolith, serviceName);
+	require("./index").generate(inputFile, userOutputDirectory, isApiMonolith, serviceName, axiosVersion);
 }

--- a/index.js
+++ b/index.js
@@ -287,7 +287,7 @@ exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvide
 			.value();
 
 		const mustacheContext = {
-			MODELS: models,
+			MODELS: models
 		};
 
 		const fileContent = Mustache.render(_.toString(data), mustacheContext);

--- a/index.js
+++ b/index.js
@@ -147,7 +147,8 @@ exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvide
 						REQUEST_METHOD: pathConfig.method,
 						REQUEST_PATH: transformApiPath(pathConfig.path, pathConfig.parameters)
 					};
-				})
+				}),
+				USE_NEW_AXIOS_TYPES: useNewAxiosHeaderTypes 
 			};
 
 			if (!fs.existsSync(serviceDirectory)) {
@@ -287,7 +288,6 @@ exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvide
 
 		const mustacheContext = {
 			MODELS: models,
-			USE_NEW_AXIOS_TYPES: useNewAxiosHeaderTypes 
 		};
 
 		const fileContent = Mustache.render(_.toString(data), mustacheContext);

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const pascalCase = (string) => {
  * @param {string} userProvidedServiceName - Optional service name for api file.
  */
 exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvidedServiceName, axiosVersion = 0) => {
-	const isAxiosVersionZero = axiosVersion >= 1;
+	const isAxiosVersionZero = axiosVersion < 1;
 	const serviceDirectoryName =
 		userProvidedServiceName && `${_.toLower(userProvidedServiceName)}Service`;
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,11 @@ const pascalCase = (string) => {
  * @param {boolean} isApiMonolith - flag indicating whether to treat this api as monolithic.
  * @param {string} userProvidedServiceName - Optional service name for api file.
  */
-exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvidedServiceName) => {
+exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvidedServiceName, axiosVersion = 0) => {
+	// Axios header typings change at version 1.0. See https://github.com/axios/axios/blob/v1.x/CHANGELOG.md#100---2022-10-04
+	const useNewAxiosHeaderTypes = axiosVersion >= 1;
+	console.log("using axios version", axiosVersion);
+	console.log('use new axios?', useNewAxiosHeaderTypes);
 	const serviceDirectoryName =
 		userProvidedServiceName && `${_.toLower(userProvidedServiceName)}Service`;
 
@@ -282,7 +286,8 @@ exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvide
 			.value();
 
 		const mustacheContext = {
-			MODELS: models
+			MODELS: models,
+			USE_NEW_AXIOS_TYPES: useNewAxiosHeaderTypes 
 		};
 
 		const fileContent = Mustache.render(_.toString(data), mustacheContext);

--- a/index.js
+++ b/index.js
@@ -31,8 +31,7 @@ const pascalCase = (string) => {
  * @param {string} userProvidedServiceName - Optional service name for api file.
  */
 exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvidedServiceName, axiosVersion = 0) => {
-	// Axios header typings change at version 1.0. See https://github.com/axios/axios/blob/v1.x/CHANGELOG.md#100---2022-10-04
-	const useNewAxiosHeaderTypes = axiosVersion >= 1;
+	const isAxiosVersionZero = axiosVersion >= 1;
 	const serviceDirectoryName =
 		userProvidedServiceName && `${_.toLower(userProvidedServiceName)}Service`;
 
@@ -146,7 +145,7 @@ exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvide
 						REQUEST_PATH: transformApiPath(pathConfig.path, pathConfig.parameters)
 					};
 				}),
-				USE_NEW_AXIOS_TYPES: useNewAxiosHeaderTypes 
+				IS_AXIOS_VERSION_ZERO: isAxiosVersionZero 
 			};
 
 			if (!fs.existsSync(serviceDirectory)) {

--- a/index.js
+++ b/index.js
@@ -33,8 +33,6 @@ const pascalCase = (string) => {
 exports.generate = async (inputFile, outputDirectory, isApiMonolith, userProvidedServiceName, axiosVersion = 0) => {
 	// Axios header typings change at version 1.0. See https://github.com/axios/axios/blob/v1.x/CHANGELOG.md#100---2022-10-04
 	const useNewAxiosHeaderTypes = axiosVersion >= 1;
-	console.log("using axios version", axiosVersion);
-	console.log('use new axios?', useNewAxiosHeaderTypes);
 	const serviceDirectoryName =
 		userProvidedServiceName && `${_.toLower(userProvidedServiceName)}Service`;
 

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -5,7 +5,7 @@
 /* eslint-disable  @typescript-eslint/no-empty-interface */
 /* eslint-disable  @typescript-eslint/no-unused-vars */
 import * as ApiModelTypes from "{{{TYPES_DIRECTORY}}}";
-import axios, { AxiosResponse, CancelToken } from "axios";
+import axios, { AxiosResponse, CancelToken{{#USE_NEW_AXIOS_TYPES}}, RawAxiosRequestHeaders{{/USE_NEW_AXIOS_TYPES}} } from "axios";
 
 /**
  * The service base path.
@@ -54,7 +54,7 @@ export interface {{FUNCTION_NAME}}QueryParams {
 export function {{FUNCTION_NAME}}(
 	params: {{^FUNCTION_PARAMS}}undefined{{/FUNCTION_PARAMS}}{{#FUNCTION_PARAMS}}{{FUNCTION_NAME}}Params{{/FUNCTION_PARAMS}},
 	payload: {{^FUNCTION_PAYLOAD}}undefined{{/FUNCTION_PAYLOAD}}{{#FUNCTION_PAYLOAD}}{{{.}}}{{/FUNCTION_PAYLOAD}},
-	headers: Record<string, unknown>,
+	headers: {{#USE_NEW_AXIOS_TYPES}}RawAxiosRequestHeaders{{/USE_NEW_AXIOS_TYPES}}{{^USE_NEW_AXIOS_TYPES}}Record<string, unknown>{{/USE_NEW_AXIOS_TYPES}},
 	cancelToken?: CancelToken,
 	queryParameters?: {{#QUERY_PARAMS}}{{FUNCTION_NAME}}QueryParams{{/QUERY_PARAMS}} | undefined,
 	basePathOverride?: string

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -5,7 +5,7 @@
 /* eslint-disable  @typescript-eslint/no-empty-interface */
 /* eslint-disable  @typescript-eslint/no-unused-vars */
 import * as ApiModelTypes from "{{{TYPES_DIRECTORY}}}";
-import axios, { AxiosResponse, CancelToken{{#USE_NEW_AXIOS_TYPES}}, RawAxiosRequestHeaders{{/USE_NEW_AXIOS_TYPES}} } from "axios";
+import axios, { AxiosResponse, CancelToken{{#IS_AXIOS_VERSION_ZERO}}, RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}} } from "axios";
 
 /**
  * The service base path.
@@ -54,7 +54,7 @@ export interface {{FUNCTION_NAME}}QueryParams {
 export function {{FUNCTION_NAME}}(
 	params: {{^FUNCTION_PARAMS}}undefined{{/FUNCTION_PARAMS}}{{#FUNCTION_PARAMS}}{{FUNCTION_NAME}}Params{{/FUNCTION_PARAMS}},
 	payload: {{^FUNCTION_PAYLOAD}}undefined{{/FUNCTION_PAYLOAD}}{{#FUNCTION_PAYLOAD}}{{{.}}}{{/FUNCTION_PAYLOAD}},
-	headers: {{#USE_NEW_AXIOS_TYPES}}RawAxiosRequestHeaders{{/USE_NEW_AXIOS_TYPES}}{{^USE_NEW_AXIOS_TYPES}}Record<string, unknown>{{/USE_NEW_AXIOS_TYPES}},
+	headers: {{#IS_AXIOS_VERSION_ZERO}}RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}}{{^IS_AXIOS_VERSION_ZERO}}Record<string, unknown>{{/IS_AXIOS_VERSION_ZERO}},
 	cancelToken?: CancelToken,
 	queryParameters?: {{#QUERY_PARAMS}}{{FUNCTION_NAME}}QueryParams{{/QUERY_PARAMS}} | undefined,
 	basePathOverride?: string

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -5,7 +5,7 @@
 /* eslint-disable  @typescript-eslint/no-empty-interface */
 /* eslint-disable  @typescript-eslint/no-unused-vars */
 import * as ApiModelTypes from "{{{TYPES_DIRECTORY}}}";
-import axios, { AxiosResponse, CancelToken{{#IS_AXIOS_VERSION_ZERO}}, RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}} } from "axios";
+import axios, { AxiosResponse, CancelToken{{^IS_AXIOS_VERSION_ZERO}}, RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}} } from "axios";
 
 /**
  * The service base path.
@@ -54,7 +54,7 @@ export interface {{FUNCTION_NAME}}QueryParams {
 export function {{FUNCTION_NAME}}(
 	params: {{^FUNCTION_PARAMS}}undefined{{/FUNCTION_PARAMS}}{{#FUNCTION_PARAMS}}{{FUNCTION_NAME}}Params{{/FUNCTION_PARAMS}},
 	payload: {{^FUNCTION_PAYLOAD}}undefined{{/FUNCTION_PAYLOAD}}{{#FUNCTION_PAYLOAD}}{{{.}}}{{/FUNCTION_PAYLOAD}},
-	headers: {{#IS_AXIOS_VERSION_ZERO}}RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}}{{^IS_AXIOS_VERSION_ZERO}}Record<string, unknown>{{/IS_AXIOS_VERSION_ZERO}},
+	headers: {{^IS_AXIOS_VERSION_ZERO}}RawAxiosRequestHeaders{{/IS_AXIOS_VERSION_ZERO}}{{#IS_AXIOS_VERSION_ZERO}}Record<string, unknown>{{/IS_AXIOS_VERSION_ZERO}},
 	cancelToken?: CancelToken,
 	queryParameters?: {{#QUERY_PARAMS}}{{FUNCTION_NAME}}QueryParams{{/QUERY_PARAMS}} | undefined,
 	basePathOverride?: string


### PR DESCRIPTION
In Axios v1 release, header types changed to defined types
Previous were `Record`

Type changes from `Record` https://github.com/axios/axios/pull/4334/files
Addition of defined types including `RawAxiosHeaders` https://github.com/axios/axios/pull/4787/files
Axios v1 Release notes https://github.com/axios/axios/pull/4787/files

This pr adds additional cli flag `v` to specify version to support and conditionally updates service files to new header types
